### PR TITLE
Improve teleop update loop

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/subsystems/DriveBase.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/subsystems/DriveBase.java
@@ -57,8 +57,8 @@ public class DriveBase {
 
     public void teleop(boolean f) {
         setFieldCentric(f);
-        getTeleopMovement();
         follower.setStartingPose(robot.getPoseEstimate());
+        follower.startTeleopDrive();
         setState(State.TELEOP);
     }
 
@@ -133,7 +133,7 @@ public class DriveBase {
                 }
                 break;
             case TELEOP:
-                follower.startTeleopDrive();
+                getTeleopMovement();
                 break;
             default:
                 // just in case we get an invalid state


### PR DESCRIPTION
## Summary
- make DriveBase.startTeleopDrive run only when entering TELEOP
- update joystick values each loop while in TELEOP state

## Testing
- `./gradlew test --stacktrace` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fa1bfeff08328a7ec3d9baa313e2f