### PR TITLE
Refactor task completion methods

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/subsystems/old/LinkageSlideTask.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/subsystems/old/LinkageSlideTask.java
@@ -24,7 +24,7 @@ class LinkageSlideTask extends Task {
     }
 
     @Override
-    public boolean isFinished() {
+    public boolean shouldTerminate() {
         return !slide.isMoving();
     }
 }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/utility/commands/DriveBaseTask.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/utility/commands/DriveBaseTask.java
@@ -27,7 +27,7 @@ class DriveBaseTask extends Task {
     }
 
     @Override
-    public boolean isFinished() {
+    public boolean shouldTerminate() {
         return !driveBase.isFollowing();
     }
 }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/utility/commands/GroupTask.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/utility/commands/GroupTask.java
@@ -27,9 +27,9 @@ public class GroupTask extends Task {
     }
 
     @Override
-    public boolean isFinished() {
+    public boolean shouldTerminate() {
         for (Task task : subTasks) {
-            if (!task.isFinished()) {
+            if (!task.shouldTerminate()) {
                 return false;
             }
         }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/utility/commands/LinearSlideTask.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/utility/commands/LinearSlideTask.java
@@ -24,7 +24,7 @@ public class LinearSlideTask extends Task {
     }
 
     @Override
-    public boolean isFinished() {
+    public boolean shouldTerminate() {
         return !slide.isMoving();
     }
 }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/utility/commands/Task.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/utility/commands/Task.java
@@ -19,8 +19,8 @@ public abstract class Task {
     // Called repeatedly while running (example: keep updating motor movement)
     public abstract void update();
 
-    // Define when the task is considered finished (example: motor reached target)
-    public abstract boolean isFinished();
+    // Define when the task should terminate (example: motor reached target)
+    public abstract boolean shouldTerminate();
 
     // Connects this task to depend on another task finishing first
     public Task then(Task next) {
@@ -36,11 +36,11 @@ public abstract class Task {
 
     // Internal: Can this task start now? (Are all dependencies finished and condition true?)
     boolean canStart() {
-        return startCondition.getAsBoolean() && dependencies.stream().allMatch(Task::isDone);
+        return startCondition.getAsBoolean() && dependencies.stream().allMatch(Task::isTerminated);
     }
 
-    // Internal: Is this task finished?
-    boolean isDone() {
+    // Internal: Has this task terminated?
+    boolean isTerminated() {
         return finished;
     }
 

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/utility/commands/TaskRunner.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/utility/commands/TaskRunner.java
@@ -25,7 +25,7 @@ public class TaskRunner {
 
             if (task.hasStarted()) { // If the task has started, keep updating it
                 task.update();
-                if (task.isFinished()) { // If the task finishes, mark it done
+                if (task.shouldTerminate()) { // If the task terminates, mark it done
                     task.markFinished();
                     activeTasks.remove(task);
                 }


### PR DESCRIPTION
## Summary
- update Task API from `isFinished()`/`isDone()` to `shouldTerminate()`/`isTerminated()`
- adjust all command tasks to use the new names
- update old LinkageSlideTask to compile with the refactored API

## Testing
- `./gradlew build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854227ff350832880a92c08058556ed